### PR TITLE
REPO-1323: Upgrade Rhino to 1.7.9.

### DIFF
--- a/spring-webscripts/spring-webscripts/pom.xml
+++ b/spring-webscripts/spring-webscripts/pom.xml
@@ -24,11 +24,10 @@
          <version>${project.version}</version>
       </dependency>
       
-      <!-- Dependency on Alfresco patched version of Rhino available in artifact.alfresco.com -->
       <dependency>
          <groupId>org.mozilla</groupId>
          <artifactId>rhino</artifactId>
-         <version>1.7R4-alfresco-patched</version>
+         <version>1.7.9</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Rhino version changed to *1.7.9*, which is the latest release - 

I also update the Bamboo build to use Java 1.8 - https://bamboo.alfresco.com/bamboo/browse/SRVC-SURF7-3 - green build on the branch