### PR TITLE
MNT-20195 Share - Information Exposure through verbose error messages

### DIFF
--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/errorcode.lib.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/errorcode.lib.ftl
@@ -1,0 +1,15 @@
+<#-- MNT-20195 (LM-190214): strip out and return error code from given error message. -->
+<#function getErrorCode message>
+   <#assign code = "">
+   
+   <#if message?? && message?is_string>
+      <!-- substring first 8 characters from message that usually be the error code id. -->
+      <#assign instanceId = message?substring(0, 8)>
+      <!-- check if these codes are 'numeric'. -->
+      <#if instanceId?matches("^[0-9]*$")>
+         <#assign code = instanceId>
+      </#if>
+   </#if>
+   
+   <#return code>
+</#function>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/fbml.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/fbml.status.ftl
@@ -6,8 +6,8 @@
 
 <div id="appbody">
 
-<!-- MNT-20195: import error utility file. (LM-190130) -->
-<#import "error.utils.ftl" as errorLib />
+<!-- MNT-20195 (LM-190214): import errorcode lib. -->
+<#import "errorcode.lib.ftl" as errorLib />
 
 <table>
  <tr>
@@ -19,11 +19,8 @@
 <table>
  <tr><td><b>Error:</b><td>${status.codeName} (${status.code}) - ${status.codeDescription}
  <tr><td>&nbsp;
- <!-- 
- 	MNT-20195: hide server, time and stacktrace info, show error log id or message.
- 	LM-190310: code changes on line 26-31.
- -->
- <#assign errorId = errorLib.getErrorId(status.message)>
+ <!-- MNT-20195 (LM-190214): hide server, time and stacktrace info, show error error / error message. -->
+ <#assign errorId = errorLib.getErrorCode(status.message)>
  <#if errorId?has_content>
  <tr><td><b>Error Log Number:</b><td>${errorId}
  <#else>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/fbml.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/fbml.status.ftl
@@ -6,6 +6,9 @@
 
 <div id="appbody">
 
+<!-- MNT-20195: import error utility file. (LM-190130) -->
+<#import "error.utils.ftl" as errorLib />
+
 <table>
  <tr>
     <td><img src="${url.context}/images/logo/AlfrescoLogo32.png" alt="Alfresco" /></td>
@@ -16,13 +19,16 @@
 <table>
  <tr><td><b>Error:</b><td>${status.codeName} (${status.code}) - ${status.codeDescription}
  <tr><td>&nbsp;
+ <!-- 
+ 	MNT-20195: hide server, time and stacktrace info, show error log id or message.
+ 	LM-190310: code changes on line 26-31.
+ -->
+ <#assign errorId = errorLib.getErrorId(status.message)>
+ <#if errorId?has_content>
+ <tr><td><b>Error Log Number:</b><td>${errorId}
+ <#else>
  <tr><td><b>Message:</b><td>${status.message!"<i>&lt;Not specified&gt;</i>"}
- <#if status.exception?exists>
-   <tr><td>&nbsp;     
-   <@recursestack status.exception/>
  </#if>
- <tr><td><b>Server</b>:<td>Alfresco ${server.edition?html} v${server.version?html} schema ${server.schema?html}
- <tr><td><b>Time</b>:<td>${date?datetime}
  <tr><td>&nbsp;
 </table>
 

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/json.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/json.status.ftl
@@ -7,19 +7,19 @@
     "description" : "${status.codeDescription}"
   },  
   
-  <#-- Exception details -->
-  "message" : "${jsonUtils.encodeJSONString(status.message)}",  
-  "exception" : "<#if status.exception??>${jsonUtils.encodeJSONString(status.exception.class.name)}<#if status.exception.message??> - ${jsonUtils.encodeJSONString(status.exception.message)}</#if></#if>",
-  
-  <#-- Exception call stack --> 
-  "callstack" : 
-  [ 
-  	  <#if status.exception??>""<@recursestack exception=status.exception/></#if> 
-  ],
-  
-  <#-- Server details and time stamp -->
-  "server" : "${server.edition?xml} v${server.version?xml} schema ${server.schema?xml}",
-  "time" : "${date?datetime}"
+  <#--
+  	MNT-20195: hide Exception details, call stack, Server details and timestamp. Show either error log number or error message.
+  	LM-190130: code changes on line 28-36.
+  -->
+  <#import "error.utils.ftl" as errorLib />
+  <#assign errorId = errorLib.getErrorId(status.message)>
+  <#if errorId?has_content>
+  <#-- Error Log Number -->
+  "errorLogNumber": "${errorId}"
+  <#else>
+  <#-- Exception message -->
+  "message" : "${jsonUtils.encodeJSONString(status.message)}"
+  </#if>
 }
 
 <#macro recursestack exception>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/json.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/json.status.ftl
@@ -7,12 +7,9 @@
     "description" : "${status.codeDescription}"
   },  
   
-  <#--
-  	MNT-20195: hide Exception details, call stack, Server details and timestamp. Show either error log number or error message.
-  	LM-190130: code changes on line 28-36.
-  -->
-  <#import "error.utils.ftl" as errorLib />
-  <#assign errorId = errorLib.getErrorId(status.message)>
+  <#-- MNT-20195 (LM-190214): hide Exception details, call stack, Server details and timestamp. Show either error log number or error message. -->
+  <#import "errorcode.lib.ftl" as codeLib />
+  <#assign errorId = codeLib.getErrorCode(status.message)>
   <#if errorId?has_content>
   <#-- Error Log Number -->
   "errorLogNumber": "${errorId}"

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/status.ftl
@@ -1,5 +1,5 @@
-<#-- MNT-20195: import new utility file. (LM-190130) -->
-<#import "error.utils.ftl" as errorLib />
+<#-- MNT-20195 (LM-190130): import errorcode lib. -->
+<#import "errorcode.lib.ftl" as codeLib />
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -23,11 +23,8 @@
          <table>
             <tr><td><b>${status.code} Description:</b></td><td> ${status.codeDescription}</td></tr>
             <tr><td>&nbsp;</td></tr>
-            <!-- 
-            	MNT-20195: hide stack trace, server and timestamp, show error log number or error message.
-            	LM-190130: code changes on line 30-35.
-            -->
-            <#assign errorId = errorLib.getErrorId(status.message)>
+            <!-- MNT-20195 (LM-190214): hide stack trace, server and timestamp, show error log number/error message. -->
+            <#assign errorId = codeLib.getErrorCode(status.message)>
             <#if errorId?has_content>
                <tr><td><b>Error Log Number: </b></td><td>${errorId}</td></tr>
             <#else>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/status.ftl
@@ -1,3 +1,6 @@
+<#-- MNT-20195: import new utility file. (LM-190130) -->
+<#import "error.utils.ftl" as errorLib />
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
    <head>
@@ -20,16 +23,15 @@
          <table>
             <tr><td><b>${status.code} Description:</b></td><td> ${status.codeDescription}</td></tr>
             <tr><td>&nbsp;</td></tr>
-            <tr><td><b>Message:</b></td><td><#if status.message??>${status.message?html}<#else><i>&lt;Not specified&gt;</i></#if></td></tr>
-            <#if status.exception?exists>
-            <tr><td></td><td>&nbsp;</td></tr>
-            <@recursestack status.exception/>
-            </#if>
-            <tr><td><b>Server</b>:</td><td>${server.edition?html} v${server.version?html} schema ${server.schema?html}</td></tr>
-            <tr><td><b>Time</b>:</td><td>${date?datetime}</td></tr>
-            <tr><td></td><td>&nbsp;</td></tr>
-            <#if webscript?exists>
-            <tr><td><b>Diagnostics</b>:</td><td><a href="${url.serviceContext}/script/${webscript.id}">Inspect Web Script (${webscript.id})</a></td></tr>
+            <!-- 
+            	MNT-20195: hide stack trace, server and timestamp, show error log number or error message.
+            	LM-190130: code changes on line 30-35.
+            -->
+            <#assign errorId = errorLib.getErrorId(status.message)>
+            <#if errorId?has_content>
+               <tr><td><b>Error Log Number: </b></td><td>${errorId}</td></tr>
+            <#else>
+               <tr><td><b>Message:</b></td><td><#if status.message??>${status.message?html}<#else><i>&lt;Not specified&gt;</i></#if></td></tr>
             </#if>
          </table>
       </div>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/xml.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/xml.status.ftl
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<#-- MNT-20195: import new utility file. (LM-190130) -->
+<#import "error.utils.ftl" as errorLib />
+
 <response>
   <status>
     <code>${status.code}</code>
     <name>${status.codeName}</name>
     <description>${status.codeDescription}</description>
   </status>
+  <#--
+  	MNT-20195: hide stack trace, server and time, show error log number or error message.
+  	LM-190130: code changes on line 15-20.
+  -->
+  <#assign errorId = errorLib.getErrorId(status.message)>
+  <#if errorId?has_content>
+  <errorLogNumber>${errorId}</errorLogNumber>
+  <#else>
   <message>${status.message!""}</message>
-  <exception><#if status.exception?exists>${status.exception.class.name}<#if status.exception.message?exists> - ${status.exception.message}</#if></#if></exception>
-  <callstack>
-  <#if status.exception?exists>
-   <@recursestack status.exception/>
   </#if>
-  </callstack>
-  <server>${server.edition?xml} v${server.version?xml} schema ${server.schema?xml}</server>
-  <time>${date?datetime}</time>
 </response>
 
 <#macro recursestack exception>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/xml.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/xml.status.ftl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<#-- MNT-20195: import new utility file. (LM-190130) -->
-<#import "error.utils.ftl" as errorLib />
+<#-- MNT-20195 (LM-190214): import errorcode lib -->
+<#import "errorcode.lib.ftl" as errorLib />
 
 <response>
   <status>
@@ -8,11 +8,8 @@
     <name>${status.codeName}</name>
     <description>${status.codeDescription}</description>
   </status>
-  <#--
-  	MNT-20195: hide stack trace, server and time, show error log number or error message.
-  	LM-190130: code changes on line 15-20.
-  -->
-  <#assign errorId = errorLib.getErrorId(status.message)>
+  <#-- MNT-20195 (LM-190214): hide stack trace, server and time, show error log number or error message. -->
+  <#assign errorId = errorLib.getErrorCode(status.message)>
   <#if errorId?has_content>
   <errorLogNumber>${errorId}</errorLogNumber>
   <#else>


### PR DESCRIPTION
There are a number of places in alfresco webscripts where information about the underlying infrastructure is exposed through verbose error messages.

In the webscript FTL,
- display the error log id generated during exception, this will be the reference for the admin user to look in the log file.
- if error log id is not available, display the error message, but hide other unnecessary information exposure, like server and webscript versions.