### PR TITLE
MNT-21097 : CLONE - [Security] - CVE-2014-0114 - commons-beanutils-1.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
MNT-21097 - Upgraded commons-beanutils dependency to 1.9.4 (latest version to date)