### PR TITLE
SFDCENG-804: Check SFDC integration compatibility with SameSite=Lax c…

### DIFF
--- a/spring-webscripts/spring-webscripts/src/main/java/org/springframework/extensions/webscripts/servlet/CSRFFilter.java
+++ b/spring-webscripts/spring-webscripts/src/main/java/org/springframework/extensions/webscripts/servlet/CSRFFilter.java
@@ -780,7 +780,7 @@ public class CSRFFilter implements Filter
             userCookie += " Max-Age=" + TIMEOUT + ";";
             if (HTTP_SECURED_SESSION_PROP)
             {
-                userCookie += " Secure; HttpOnly;";
+                userCookie += " Secure;";
             }
             if (COOKIES_SAMESITE != null)
             {
@@ -956,7 +956,7 @@ public class CSRFFilter implements Filter
             userCookie += " Max-Age=0;";
             if (HTTP_SECURED_SESSION_PROP)
             {
-                userCookie += " Secure; HttpOnly;";
+                userCookie += " Secure;";
             }
             if (COOKIES_SAMESITE != null)
             {


### PR DESCRIPTION
CSRF cookie is accessed from javascript ([example](https://github.com/Alfresco/share/blob/3678bb5b18c31fc31269a2da5404a6f5bc1a6add/web-framework-commons/src/main/webapp/js/alfresco.js#L7678)) so it needs to be not HttpOnly. Because HttpOnly cookies cannot be accessed from JavaScript code. ([Documentation](https://javascript.info/cookie#httponly))