### PR TITLE
APPS-480: Change commons-codec from 1.12 to 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.12</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
Change commons-codec from 1.12 to 1.14 to improve security (WhiteSource WS-2019-0379)