### PR TITLE
APPS-595 : Changes from MNT-20195 break Travis build for alfresco-community-repo

### DIFF
--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/fbml.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/fbml.status.ftl
@@ -22,7 +22,7 @@
                 <!-- MNT-20195 (LM-190214): hide server, time and stacktrace info, show error error / error message. -->
                 <#assign errorId = errorLib.getErrorCode(status.message)>
                 <#if errorId?has_content>
-        <tr><td><b>Error Log Number:</b><td>${errorId}
+        <tr><td><b>Message:</b><td>${errorId}
                 <#else>
         <tr><td><b>Message:</b><td>${status.message!"<i>&lt;Not specified&gt;</i>"}
                 </#if>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/json.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/json.status.ftl
@@ -12,7 +12,7 @@
 <#assign errorId = codeLib.getErrorCode(status.message)>
 <#if errorId?has_content>
 <#-- Error Log Number -->
-    "errorLogNumber": "${errorId}"
+    "message": "${errorId}"
 <#else>
 <#-- Exception message -->
     "message" : "${jsonUtils.encodeJSONString(status.message)}"

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/status.ftl
@@ -26,7 +26,7 @@
       <!-- MNT-20195 (LM-190214): hide stack trace, server and timestamp, show error log number/error message. -->
       <#assign errorId = codeLib.getErrorCode(status.message)>
       <#if errorId?has_content>
-         <tr><td><b>Error Log Number: </b></td><td>${errorId}</td></tr>
+         <tr><td><b>Message: </b></td><td>${errorId}</td></tr>
       <#else>
          <tr><td><b>Message:</b></td><td><#if status.message??>${status.message?html}<#else><i>&lt;Not specified&gt;</i></#if></td></tr>
       </#if>

--- a/spring-webscripts/spring-webscripts/src/main/resources/webscripts/xml.status.ftl
+++ b/spring-webscripts/spring-webscripts/src/main/resources/webscripts/xml.status.ftl
@@ -11,7 +11,7 @@
     <#-- MNT-20195 (LM-190214): hide stack trace, server and time, show error log number or error message. -->
     <#assign errorId = errorLib.getErrorCode(status.message)>
     <#if errorId?has_content>
-        <errorLogNumber>${errorId}</errorLogNumber>
+        <message>${errorId}</message>
     <#else>
         <message>${status.message!""}</message>
     </#if>


### PR DESCRIPTION
Due to a change in the JSON FTL the response sometimes changes, having either "message" or "errorLogNumber".
This could result in breaking changes. The proposed remedy just uses "message", but will not contain the sensitive information (just the error number that previously would be stored in the "errorLogNumber").
I've also modified the other FTLs for consistency, and taking into account the possibility of UI test failures.

