### PR TITLE
[PRODSEC-4421] Fixed locale parsing with trailing - or _

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12</version>
+            <version>3.12.0</version>
         </dependency>
      </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.12</version>
         </dependency>
      </dependencies>
   </dependencyManagement>

--- a/spring-surf-core/spring-surf-core/src/main/java/org/springframework/extensions/surf/util/I18NUtil.java
+++ b/spring-surf-core/spring-surf-core/src/main/java/org/springframework/extensions/surf/util/I18NUtil.java
@@ -323,6 +323,21 @@ public class I18NUtil
             return locale;
         }
 
+        StringTokenizer t = new StringTokenizer(localeStr, "_-");
+        int tokens = t.countTokens();
+        if (tokens == 1)
+        {
+            localeStr = t.nextToken();
+        }
+        else if (tokens == 2)
+        {
+            localeStr = t.nextToken() + "_" + t.nextToken();
+        }
+        else if (tokens == 3)
+        {
+            localeStr = t.nextToken() + "_" + t.nextToken() + "_" + t.nextToken();
+        }
+
         try
         {
             locale = LocaleUtils.toLocale(localeStr);

--- a/spring-surf-core/spring-surf-core/src/test/java/org/springframework/extensions/surf/util/I18NUtilTest.java
+++ b/spring-surf-core/spring-surf-core/src/test/java/org/springframework/extensions/surf/util/I18NUtilTest.java
@@ -22,8 +22,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.lang3.LocaleUtils;
-
 import junit.framework.TestCase;
 
 /**
@@ -183,6 +181,9 @@ public class I18NUtilTest extends TestCase
         assertEquals(Locale.getDefault(), I18NUtil.parseLocale("<button onclick=alert(1)>"));
         assertEquals(Locale.getDefault(), I18NUtil.parseLocale("123abc"));
         assertEquals(new Locale("abc"), I18NUtil.parseLocale("abc"));
+        assertEquals(Locale.ITALY, I18NUtil.parseLocale("it_IT"));
+        assertEquals(Locale.ITALY, I18NUtil.parseLocale("it_IT_"));
+        assertEquals(new Locale("pt"), I18NUtil.parseLocale("pt_"));
     }
 
     public void testResourceBundleOrder()


### PR DESCRIPTION
Repo tests were failing as locale strings with a trailing underscore were being used.