### PR TITLE
[ACS-9045] Bump Spring Framework to 6.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         stage: [ source_clear ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
           cp -v _ci/settings.xml ${HOME}/.m2/ || cp -v .travis.settings.xml ${HOME}/.m2/settings.xml
 
       - name: "Cache the Maven packages to speed up build"
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -72,13 +72,13 @@ jobs:
     if: ${{ ( !contains(github.event.head_commit.message, '[no-release]')  ) && ( github.ref_name == 'master' || startsWith(github.ref_name, 'support/')) && github.event.repository.fork==false }}
     needs: Test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: "Set up Java"
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17
@@ -92,14 +92,14 @@ jobs:
           cp -v _ci/settings.xml ${HOME}/.m2/ || cp -v .travis.settings.xml ${HOME}/.m2/settings.xml
 
       - name: "Cache the Maven packages to speed up build"
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
       - name: Get branch name
-        uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@v1.23.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@v8.6.1
 
       - name: "Push to Nexus"
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
-         <version>4.12</version>
+         <version>4.13.1</version>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -121,7 +121,7 @@
   </dependencyManagement>
 
    <properties>
-      <spring.version>6.1.13</spring.version>
+      <spring.version>6.2.0</spring.version>
       <java.version>17</java.version>
       <maven.build.sourceVersion>${java.version}</maven.build.sourceVersion>
       <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
    </parent>
    <groupId>org.alfresco.surf</groupId>
    <artifactId>spring-surf-webscripts-parent</artifactId>
-   <version>9.5-SNAPSHOT</version>
+   <version>10.0-SNAPSHOT</version>
    <name>WebScripts</name>
    <description>WebScripts modules</description>
    <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.13.0</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/spring-surf-core/spring-surf-core-configservice/pom.xml
+++ b/spring-surf-core/spring-surf-core-configservice/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.alfresco.surf</groupId>
 		<artifactId>spring-surf-webscripts-parent</artifactId>
-		<version>9.5-SNAPSHOT</version>
+		<version>10.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/spring-surf-core/spring-surf-core/pom.xml
+++ b/spring-surf-core/spring-surf-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.alfresco.surf</groupId>
 		<artifactId>spring-surf-webscripts-parent</artifactId>
-		<version>9.5-SNAPSHOT</version>
+		<version>10.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/spring-webscripts/spring-webscripts-api/pom.xml
+++ b/spring-webscripts/spring-webscripts-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.alfresco.surf</groupId>
 		<artifactId>spring-surf-webscripts-parent</artifactId>
-		<version>9.5-SNAPSHOT</version>
+		<version>10.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/spring-webscripts/spring-webscripts/pom.xml
+++ b/spring-webscripts/spring-webscripts/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
          <groupId>org.mozilla</groupId>
          <artifactId>rhino</artifactId>
-         <version>1.7.11</version>
+         <version>1.7.12</version>
       </dependency>
 
       <dependency>
@@ -86,7 +86,7 @@
       <dependency>
          <groupId>org.apache.httpcomponents</groupId>
          <artifactId>httpclient</artifactId>
-         <version>4.5.9</version>
+         <version>4.5.13</version>
       </dependency>
 
       <!-- Additional Spring 3.0 dependencies -->

--- a/spring-webscripts/spring-webscripts/pom.xml
+++ b/spring-webscripts/spring-webscripts/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.alfresco.surf</groupId>
       <artifactId>spring-surf-webscripts-parent</artifactId>
-      <version>9.5-SNAPSHOT</version>
+      <version>10.0-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/spring-webscripts/spring-webscripts/src/main/resources/org/springframework/extensions/webscripts/spring-webscripts-mvc-context.xml
+++ b/spring-webscripts/spring-webscripts/src/main/resources/org/springframework/extensions/webscripts/spring-webscripts-mvc-context.xml
@@ -35,16 +35,12 @@
    <!-- Web Scripts Framework Controllers -->
    <bean id="endpointController" class="org.springframework.extensions.webscripts.servlet.mvc.EndPointProxyController">
       <property name="cacheSeconds" value="-1" />
-      <property name="useExpiresHeader"><value>true</value></property>
-      <property name="useCacheControlHeader"><value>true</value></property>
       <property name="configService" ref="web.config" />
       <property name="connectorService" ref="connector.service" />
       <property name="supportedMethods"><null/></property>
    </bean>
    <bean id="resourceController" class="org.springframework.extensions.webscripts.servlet.mvc.ResourceController">
       <property name="cacheSeconds" value="-1" />
-      <property name="useExpiresHeader"><value>true</value></property>
-      <property name="useCacheControlHeader"><value>true</value></property>
    </bean>
    
    <!-- Web Script View Resolver -->


### PR DESCRIPTION
Bumping Spring Framework to 6.2.0 to enable Spring upgrade in ACS.

Due to removal of `useExpiresHeader` and `useCacheControlHeader` from `WebContentGenerator.java` it was impossible to upgrade Spring to 6.2.0 in ACS since **surf-webscripts** was still requiring those properties resulting in bellow error:
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'handlerMappings' defined in URL [jar:file:/home/runner/.m2/repository/org/alfresco/surf/spring-webscripts/9.4/spring-webscripts-9.4.jar!/org/springframework/extensions/webscripts/spring-webscripts-mvc-context.xml]: Error creating bean with name 'endpointController' defined in URL [jar:file:/home/runner/.m2/repository/org/alfresco/surf/spring-webscripts/9.4/spring-webscripts-9.4.jar!/org/springframework/extensions/webscripts/spring-webscripts-mvc-context.xml]: Invalid property 'useExpiresHeader' of bean class [org.springframework.extensions.webscripts.servlet.mvc.EndPointProxyController]: Bean property 'useExpiresHeader' is not writable or has an invalid setter method. Does the parameter type of the setter match the return type of the getter?
```