### PR TITLE
PRODSEC-10332 fixed import path for updated listener class

### DIFF
--- a/spring-webscripts/spring-webscripts/src/main/resources/META-INF/web-fragment.xml
+++ b/spring-webscripts/spring-webscripts/src/main/resources/META-INF/web-fragment.xml
@@ -1,6 +1,6 @@
 <web-fragment>
    <!-- Commons FileUpload2 Jakarta - Stops reaper thread started by org.apache.commons.io.FileCleaningTracker -->
    <listener>
-      <listener-class>org.apache.commons.fileupload2.jakarta.JakartaFileCleaner</listener-class>
+      <listener-class>org.apache.commons.fileupload2.jakarta.servlet6.JakartaFileCleaner</listener-class>
    </listener>
 </web-fragment>


### PR DESCRIPTION
This change fixes broken 10.1 release. The updated fileupload2 has new import path that was not reflected in configuration file, which results in catalina exception at runtime.

![image](https://github.com/user-attachments/assets/2f68c3b4-8052-4f31-b1a0-1191981b988a)
